### PR TITLE
Single finders

### DIFF
--- a/app/controllers/api/v1/invoice_items/search_controller.rb
+++ b/app/controllers/api/v1/invoice_items/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::InvoiceItems::SearchController < ApplicationController
+  def show
+    render json: InvoiceItemSerializer.new(InvoiceItem.find_by(invoice_item_params))
+  end
+
+  private
+
+  def invoice_item_params
+    params.permit(:id, :item_id, :invoice_id, :unit_price, :quantity, :created_at, :updated_at)
+  end
+end

--- a/app/controllers/api/v1/invoices/search_controller.rb
+++ b/app/controllers/api/v1/invoices/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Invoices::SearchController < ApplicationController
+  def show
+    render json: InvoiceSerializer.new(Invoice.find_by(invoice_params))
+  end
+
+  private
+
+  def invoice_params
+    params.permit(:id, :customer_id, :merchant_id, :status, :created_at, :updated_at)
+  end
+end

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Items::SearchController < ApplicationController
+  def show
+    render json: ItemSerializer.new(Item.find_by(item_params))
+  end
+
+  private
+
+  def item_params
+    params.permit(:id, :name, :description, :unit_price, :merchant_id, :created_at, :updated_at)
+  end
+end

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Merchants::SearchController < ApplicationController
+  def show
+    render json: MerchantSerializer.new(Merchant.find_by(merchant_params))
+  end
+
+  private
+
+  def merchant_params
+    params.permit(:id, :name, :created_at, :updated_at)
+  end
+end

--- a/app/controllers/api/v1/transactions/search_controller.rb
+++ b/app/controllers/api/v1/transactions/search_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Transactions::SearchController < ApplicationController
+  def show
+    render json: TransactionSerializer.new(Transaction.find_by(transaction_params))
+  end
+
+  private
+
+  def transaction_params
+    params.permit(:id, :invoice_id, :credit_card_number, :credit_card_expiration_date, :created_at, :updated_at)
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,7 +1,10 @@
 class Invoice < ApplicationRecord
-  validates_presence_of :customer_id, :merchant_id, :status
-  
+  validates_presence_of :customer_id, :merchant_id, :status, :created_at, :updated_at
+
   has_many :transactions
   has_many :invoice_items
   has_many :items, through: :invoice_items
+
+  belongs_to :customer
+  belongs_to :merchant
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,5 +1,5 @@
 class InvoiceItem < ApplicationRecord
-  validates_presence_of :item_id, :invoice_id
+  validates_presence_of :item_id, :invoice_id, :created_at, :updated_at
   validates_numericality_of :quantity, greater_than_or_equal_to: 0, only_integer: true
   validates_numericality_of :unit_price, greater_than_or_equal_to: 0, only_integer: true
   belongs_to :invoice

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,9 @@
 class Item < ApplicationRecord
-  validates_presence_of :name, :description, :merchant_id
+  validates_presence_of :name, :description, :merchant_id, :created_at, :updated_at
   validates_numericality_of :unit_price, greater_than_or_equal_to: 0, only_integer: true
 
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
+
+  belongs_to :merchant
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,3 +1,7 @@
 class Merchant < ApplicationRecord
   validates_presence_of :name
+
+  has_many :items
+  has_many :invoices
+  has_many :invoice_items, through: :invoices
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,5 @@
 class Transaction < ApplicationRecord
-  validates_presence_of :invoice_id, :result
+  validates_presence_of :invoice_id, :result, :created_at, :updated_at
   validates_numericality_of :credit_card_number, greater_than: 0, only_integer: true
   validates :credit_card_expiration_date, presence: true, allow_blank: true
 

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,4 +1,4 @@
 class InvoiceItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :item_id, :invoice_id, :quantity, :unit_price, :created_at, :updated_at
+  attributes :id, :item_id, :invoice_id, :quantity, :unit_price, :created_at, :updated_at
 end

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,4 +1,4 @@
 class InvoiceItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :item_id, :invoice_id, :quantity, :unit_price
+  attributes :item_id, :invoice_id, :quantity, :unit_price, :created_at, :updated_at
 end

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,4 +1,4 @@
 class InvoiceSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :customer_id, :merchant_id, :status
+  attributes :id, :customer_id, :merchant_id, :status,  :created_at, :updated_at
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,4 +1,4 @@
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :name, :description, :unit_price, :merchant_id
+  attributes :id, :name, :description, :unit_price, :merchant_id, :created_at, :updated_at
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,4 +1,4 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :name
+  attributes :id, :name, :created_at, :updated_at
 end

--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -1,4 +1,4 @@
 class TransactionSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :invoice_id, :credit_card_number, :credit_card_expiration_date, :result
+  attributes :id, :invoice_id, :credit_card_number, :credit_card_expiration_date, :result, :created_at, :updated_at
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,11 @@ Rails.application.routes.draw do
         get '/find_all', to: "search#show_all"
       end
 
+      namespace :invoices do
+        get '/find', to: "search#show"
+        get '/find_all', to: "search#show_all"
+      end
+
       resources :customers, only: [:index, :show]
       resources :invoice_items, only: [:index, :show]
       resources :invoices, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,11 @@ Rails.application.routes.draw do
         get '/find_all', to: "search#show_all"
       end
 
+      namespace :transactions do
+        get '/find', to: "search#show"
+        get '/find_all', to: "search#show_all"
+      end
+
       resources :customers, only: [:index, :show]
       resources :invoice_items, only: [:index, :show]
       resources :invoices, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,11 @@ Rails.application.routes.draw do
         get '/find_all', to: "search#show_all"
       end
 
+      namespace :merchants do
+        get '/find', to: "search#show"
+        get '/find_all', to: "search#show_all"
+      end
+
       resources :customers, only: [:index, :show]
       resources :invoice_items, only: [:index, :show]
       resources :invoices, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,11 @@ Rails.application.routes.draw do
         get '/find_all', to: "search#show_all"
       end
 
+      namespace :invoice_items do
+        get '/find', to: "search#show"
+        get '/find_all', to: "search#show_all"
+      end
+
       resources :customers, only: [:index, :show]
       resources :invoice_items, only: [:index, :show]
       resources :invoices, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,11 @@ Rails.application.routes.draw do
         get '/find_all', to: "search#show_all"
       end
 
+      namespace :items do
+        get '/find', to: "search#show"
+        get '/find_all', to: "search#show_all"
+      end
+
       resources :customers, only: [:index, :show]
       resources :invoice_items, only: [:index, :show]
       resources :invoices, only: [:index, :show]

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :customer do
     first_name { "MyString" }
     last_name { "MyString" }
-    created_at { Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default) }
-    updated_at { Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default) }
+    created_at { "2010-11-02T14:37:48" }
+    updated_at { "2010-11-02T14:37:48" }
   end
 end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     invoice_id { 1 }
     quantity { 1 }
     unit_price { 1 }
+    created_at { "2010-11-02T14:37:48" }
+    updated_at { "2010-11-02T14:37:48" }
+    item
+    invoice
   end
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :invoice do
-    customer_id { "MyString" }
-    merchant_id { "MyString" }
+    customer_id { 1 }
+    merchant_id { 1 }
     status { "MyString" }
+    created_at { "2010-11-02T14:37:48" }
+    updated_at { "2010-11-02T14:37:48" }
+    customer
+    merchant
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,5 +4,8 @@ FactoryBot.define do
     description { "MyString" }
     unit_price { 1 }
     merchant_id { 1 }
+    created_at { "2010-11-02T14:37:48" }
+    updated_at { "2010-11-02T14:37:48" }
+    merchant
   end
 end

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :merchant do
     name { "MyString" }
+    created_at { "2010-11-02T14:37:48" }
+    updated_at { "2010-11-02T14:37:48" }
   end
 end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -4,5 +4,8 @@ FactoryBot.define do
     credit_card_number { 1 }
     credit_card_expiration_date { "" }
     result { "MyString" }
+    created_at { "2010-11-02T14:37:48" }
+    updated_at { "2010-11-02T14:37:48" }
+    invoice
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,5 +11,8 @@ RSpec.describe Invoice, type: :model do
     it { should have_many :transactions }
     it { should have_many :invoice_items }
     it { should have_many(:items).through(:invoice_items) }
+
+    it { should belong_to :customer }
+    it { should belong_to :merchant }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,5 +11,7 @@ RSpec.describe Item, type: :model do
   describe "relationships" do
     it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
+
+    it { should belong_to :merchant }
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -4,4 +4,11 @@ RSpec.describe Merchant, type: :model do
   describe "validations" do
     it { should validate_presence_of :name }
   end
+
+  describe "relationships" do
+    it { should have_many :items }
+    it { should have_many :invoices }
+    it { should have_many(:invoice_items).through(:invoices) }
+  end
+
 end

--- a/spec/requests/api/v1/customers_request_spec.rb
+++ b/spec/requests/api/v1/customers_request_spec.rb
@@ -61,6 +61,17 @@ describe "Customers API" do
     customer = JSON.parse(response.body)
     expect(response).to be_successful
 
-    expect(customer["data"]["attributes"]["created_at"]).to eq(created_at)
+    expect(customer["data"]["attributes"]["created_at"]).to eq(created_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
+
+  it "can find first instance by updated_at" do
+    updated_at = create(:customer).updated_at
+
+    get "/api/v1/customers/find?updated_at=#{updated_at}"
+
+    customer = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(customer["data"]["attributes"]["updated_at"]).to eq(updated_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
   end
 end

--- a/spec/requests/api/v1/invoice_items_request_spec.rb
+++ b/spec/requests/api/v1/invoice_items_request_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 describe "Invoice Items API" do
   it "sends a list of invoice items" do
-    invoice_item_1 = create(:invoice_item, item_id: create(:item).id, invoice_id: create(:invoice).id)
-    invoice_item_2 = create(:invoice_item, item_id: create(:item).id, invoice_id: create(:invoice).id)
-    invoice_item_3 = create(:invoice_item, item_id: create(:item).id, invoice_id: create(:invoice).id)
+    create_list(:invoice_item, 3)
 
     get '/api/v1/invoice_items'
 
@@ -15,7 +13,7 @@ describe "Invoice Items API" do
   end
 
   it "can get one invoice_item by its id" do
-    id = create(:invoice_item, item_id: create(:item).id, invoice_id: create(:invoice).id).id
+    id = create(:invoice_item).id
 
     get "/api/v1/invoice_items/#{id}"
 
@@ -23,5 +21,77 @@ describe "Invoice Items API" do
 
     expect(response).to be_successful
     expect(invoice_item["data"]["id"].to_i).to eq(id)
+  end
+
+  it "it can find first instance by id" do
+    id = create(:invoice_item).id
+
+    get "/api/v1/invoice_items/find?id=#{id}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice_item["data"]["id"].to_i).to eq(id)
+  end
+
+  it "can find first instance by item id" do
+    item_id = create(:invoice_item).item_id
+
+    get "/api/v1/invoice_items/find?item_id=#{item_id}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice_item["data"]["attributes"]["item_id"]).to eq(item_id)
+  end
+
+  it "can find first instance by invoice id" do
+    invoice_id = create(:invoice_item).invoice_id
+
+    get "/api/v1/invoice_items/find?invoice_id=#{invoice_id}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice_item["data"]["attributes"]["invoice_id"]).to eq(invoice_id)
+  end
+
+  it "can find first instance by unit price" do
+    unit_price = create(:invoice_item).unit_price
+
+    get "/api/v1/invoice_items/find?unit_price=#{unit_price}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice_item["data"]["attributes"]["unit_price"]).to eq(unit_price)
+  end
+
+  it "can find first instance by quantity" do
+    quantity = create(:invoice_item).quantity
+
+    get "/api/v1/invoice_items/find?quantity=#{quantity}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice_item["data"]["attributes"]["quantity"]).to eq(quantity)
+  end
+
+  it "can find first instance by created_at" do
+    created_at = create(:invoice_item).created_at
+
+    get "/api/v1/invoice_items/find?created_at=#{created_at}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(invoice_item["data"]["attributes"]["created_at"]).to eq(created_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
+
+  it "can find first instance by updated_at" do
+    updated_at = create(:invoice_item).updated_at
+
+    get "/api/v1/invoice_items/find?updated_at=#{updated_at}"
+
+    invoice_item = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(invoice_item["data"]["attributes"]["updated_at"]).to eq(updated_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
   end
 end

--- a/spec/requests/api/v1/invoices_request_spec.rb
+++ b/spec/requests/api/v1/invoices_request_spec.rb
@@ -22,4 +22,66 @@ describe "Invoices API" do
     expect(response).to be_successful
     expect(invoice["data"]["id"].to_i).to eq(id)
   end
+
+  it "it can find first instance by id" do
+    id = create(:invoice).id
+
+    get "/api/v1/invoices/find?id=#{id}"
+
+    invoice = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice["data"]["id"].to_i).to eq(id)
+  end
+
+  it "can find first instance by customer id" do
+    customer_id = create(:invoice).customer_id
+
+    get "/api/v1/invoices/find?customer_id=#{customer_id}"
+
+    invoice = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice["data"]["attributes"]["customer_id"]).to eq(customer_id)
+  end
+
+  it "can find first instance by merchant id" do
+    merchant_id = create(:invoice).merchant_id
+
+    get "/api/v1/invoices/find?merchant_id=#{merchant_id}"
+
+    invoice = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice["data"]["attributes"]["merchant_id"]).to eq(merchant_id)
+  end
+
+  it "can find first instance by status" do
+    status = create(:invoice).status
+
+    get "/api/v1/invoices/find?status=#{status}"
+
+    invoice = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(invoice["data"]["attributes"]["status"]).to eq(status)
+  end
+
+  it "can find first instance by created_at" do
+    created_at = create(:invoice).created_at
+
+    get "/api/v1/invoices/find?created_at=#{created_at}"
+
+    invoice = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(invoice["data"]["attributes"]["created_at"]).to eq(created_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
+
+  it "can find first instance by updated_at" do
+    updated_at = create(:invoice).updated_at
+
+    get "/api/v1/invoices/find?updated_at=#{updated_at}"
+
+    invoice = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(invoice["data"]["attributes"]["updated_at"]).to eq(updated_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -22,4 +22,76 @@ describe "Items API" do
     expect(response).to be_successful
     expect(item["data"]["id"].to_i).to eq(id)
   end
+
+  it "it can find first instance by id" do
+    id = create(:item).id
+
+    get "/api/v1/items/find?id=#{id}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(item["data"]["id"].to_i).to eq(id)
+  end
+
+  it "can find first instance by name" do
+    name = create(:item).name
+
+    get "/api/v1/items/find?name=#{name}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(item["data"]["attributes"]["name"]).to eq(name)
+  end
+
+  it "can find first instance by description" do
+    description = create(:item).description
+
+    get "/api/v1/items/find?description=#{description}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(item["data"]["attributes"]["description"]).to eq(description)
+  end
+
+  it "can find first instance by unit_price" do
+    unit_price = create(:item).unit_price
+
+    get "/api/v1/items/find?unit_price=#{unit_price}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(item["data"]["attributes"]["unit_price"]).to eq(unit_price)
+  end
+
+  it "can find first instance by merchant id" do
+    merchant_id = create(:item).merchant_id
+
+    get "/api/v1/items/find?merchant_id=#{merchant_id}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(item["data"]["attributes"]["merchant_id"]).to eq(merchant_id)
+  end
+
+  it "can find first instance by created_at" do
+    created_at = create(:item).created_at
+
+    get "/api/v1/items/find?created_at=#{created_at}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(item["data"]["attributes"]["created_at"]).to eq(created_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
+
+  it "can find first instance by updated_at" do
+    updated_at = create(:item).updated_at
+
+    get "/api/v1/items/find?updated_at=#{updated_at}"
+
+    item = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(item["data"]["attributes"]["updated_at"]).to eq(updated_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -22,4 +22,46 @@ describe "Merchants API" do
     expect(response).to be_successful
     expect(merchant["data"]["id"].to_i).to eq(id)
   end
+
+  it "it can find first instance by id" do
+    id = create(:merchant).id
+
+    get "/api/v1/merchants/find?id=#{id}"
+
+    merchant = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(merchant["data"]["id"].to_i).to eq(id)
+  end
+
+  it "can find first instance by name" do
+    name = create(:merchant).name
+
+    get "/api/v1/merchants/find?name=#{name}"
+
+    merchant = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(merchant["data"]["attributes"]["name"]).to eq(name)
+  end
+
+  it "can find first instance by created_at" do
+    created_at = create(:merchant).created_at
+
+    get "/api/v1/merchants/find?created_at=#{created_at}"
+
+    merchant = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(merchant["data"]["attributes"]["created_at"]).to eq(created_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
+
+  it "can find first instance by updated_at" do
+    updated_at = create(:merchant).updated_at
+
+    get "/api/v1/merchants/find?updated_at=#{updated_at}"
+
+    merchant = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(merchant["data"]["attributes"]["updated_at"]).to eq(updated_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
 end

--- a/spec/requests/api/v1/transactions_request_spec.rb
+++ b/spec/requests/api/v1/transactions_request_spec.rb
@@ -24,4 +24,66 @@ describe "Transactions API" do
     expect(response).to be_successful
     expect(transaction["data"]["id"].to_i).to eq(id)
   end
+
+  it "it can find first instance by id" do
+    id = create(:transaction).id
+
+    get "/api/v1/transactions/find?id=#{id}"
+
+    transaction = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(transaction["data"]["id"].to_i).to eq(id)
+  end
+
+  it "can find first instance by invoice id" do
+    invoice_id = create(:transaction).invoice_id
+
+    get "/api/v1/transactions/find?invoice_id=#{invoice_id}"
+
+    transaction = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(transaction["data"]["attributes"]["invoice_id"]).to eq(invoice_id)
+  end
+
+  it "can find first instance by credit_card_number" do
+    credit_card_number = create(:transaction).credit_card_number
+
+    get "/api/v1/transactions/find?credit_card_number=#{credit_card_number}"
+
+    transaction = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(transaction["data"]["attributes"]["credit_card_number"]).to eq(credit_card_number)
+  end
+
+  it "can find first instance by result" do
+    result = create(:transaction).result
+
+    get "/api/v1/transactions/find?result=#{result}"
+
+    transaction = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(transaction["data"]["attributes"]["result"]).to eq(result)
+  end
+
+  it "can find first instance by created_at" do
+    created_at = create(:transaction).created_at
+
+    get "/api/v1/transactions/find?created_at=#{created_at}"
+
+    transaction = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(transaction["data"]["attributes"]["created_at"]).to eq(created_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
+
+  it "can find first instance by updated_at" do
+    updated_at = create(:transaction).updated_at
+
+    get "/api/v1/transactions/find?updated_at=#{updated_at}"
+
+    transaction = JSON.parse(response.body)
+    expect(response).to be_successful
+
+    expect(transaction["data"]["attributes"]["updated_at"]).to eq(updated_at.strftime('%Y-%m-%dT%H:%M:%S.000Z'))
+  end
 end


### PR DESCRIPTION
Add a find endpoint that returns a single object representation

Request url looks likes this:
`GET /api/v1/merchants/find?parameters`

Request Parameters depend on specific attributes of a given model.

`GET /api/v1/merchants/find?name=Schroeder-Jerde`

An example of a JSON output from the above endpoint would look like this:

```ruby
{
  "data": {
    "id": "1",
    "type": "merchant",
    "attributes": {
      "name": "Schroeder-Jerde"
    }
  }
}
```
